### PR TITLE
Fixed an issue with the baseline in rem function

### DIFF
--- a/_rem.scss
+++ b/_rem.scss
@@ -7,7 +7,7 @@ $guss-rem-baseline: 10px !default;
     @if type-of($value) == list {
         $result: ();
         @each $e in $value {
-            $result: append($result, rem($e));
+            $result: append($result, rem($e, $baseline));
         }
         @return $result;
     } @else {


### PR DESCRIPTION
Consider the following code snippet:

``` scss
.test {
  padding: rem(10px 20px, 15px);
}
```

As of today, it yields `1rem 2rem`, because if the first argument is a list, the baseline is not correctly passed in the recursive call, leading to a calculation with the default baseline.

With the fix, it should now yields `0.66667rem 1.33333rem`.
